### PR TITLE
Fixes bug causing card widths to be too wide on "shows" page 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# .idea
+.idea

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -5,7 +5,10 @@ import { getAllShows } from '@l/graphcms'
 
 export default function Shows({ shows }) {
   return (
-    <Layout title="next-graphcms-shows / Shows">
+    <Layout
+      title="next-graphcms-shows / Shows"
+      maxWidth="900px"
+    >
       <Title>Shows</Title>
       <Grid>
         {shows.map(show => (


### PR DESCRIPTION
# Summary
"Shows" page's layout width was inconsistent with the similar layouts on other pages. 

# Solution
Set the "Layout" component's "maxWidth" prop to be consistent. 
